### PR TITLE
more guided fuzzing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,10 @@ services:
       context: ./images/cheroot
       args:
         APP_VERSION: main
+    volumes:
+      - /tmp/cheroot:/tmp
     x-props:
+      is-traced: true
       role: server
   civetweb:
     build:
@@ -76,6 +79,7 @@ services:
       - /tmp/gunicorn:/tmp
     x-props:
       role: server
+      is-traced: true
   h2o:
     build:
       context: ./images/h2o
@@ -108,7 +112,10 @@ services:
       context: ./images/hypercorn
       args:
         APP_VERSION: main
+    volumes:
+      - /tmp/hypercorn:/tmp
     x-props:
+      is-traced: true
       role: server
   jetty:
     build:
@@ -266,7 +273,10 @@ services:
       context: ./images/werkzeug
       args:
         APP_VERSION: main
+    volumes:
+      - /tmp/werkzeug:/tmp
     x-props:
+      is-traced: true
       role: server
   apache_proxy:
     depends_on:

--- a/images/aiohttp/Dockerfile
+++ b/images/aiohttp/Dockerfile
@@ -2,6 +2,7 @@ FROM http-garden-soil:latest
 
 RUN apt -y update && apt -y upgrade && apt -y install libffi-dev python3-venv && git clone "https://github.com/aio-libs/aiohttp" && python3 -m venv /app/aiohttp/env
 
+# ENV YARL_NO_EXTENSIONS=1
 ENV AIOHTTP_NO_EXTENSIONS=1
 ARG APP_VERSION
 RUN cd /app/aiohttp && git checkout $APP_VERSION && git submodule update --init --recursive && . /app/aiohttp/env/bin/activate && pip install . && pip install /app/python-afl

--- a/images/cheroot/Dockerfile
+++ b/images/cheroot/Dockerfile
@@ -7,4 +7,4 @@ RUN cd /app/cheroot && git checkout $APP_VERSION && pip3 install --break-system-
 
 COPY server.py .
 
-CMD ["python3", "server.py"]
+CMD ["afl-showmap", "-o", "/tmp/trace", "-t", "2147483647", "--", "python3", "server.py"]

--- a/images/cheroot/server.py
+++ b/images/cheroot/server.py
@@ -36,5 +36,7 @@ def app(environ, start_response) -> list[bytes]:
     )
     return [response_body]
 
+import afl
+afl.init()
 
 Server(("0.0.0.0", 80), WSGIPathInfoDispatcher({"/": app})).start()

--- a/images/gunicorn/Dockerfile
+++ b/images/gunicorn/Dockerfile
@@ -6,5 +6,6 @@ ARG APP_VERSION
 RUN cd /app/gunicorn && git checkout $APP_VERSION && pip3 install . --break-system-packages
 
 COPY ./server.py /app
-# For some reason, afl-showmap just isn't working...
-CMD ["python3", "-m", "gunicorn", "--permit-unconventional-http-method", "--worker-class=gevent", "--workers=1", "--worker-connections=1000", "--bind", "0.0.0.0:80", "server:app"]
+COPY ./gunicorn.conf.py /gunicorn.conf.py
+
+CMD ["afl-showmap", "-o", "/tmp/trace", "-t", "2147483647", "--", "python3", "-m", "gunicorn", "--permit-unconventional-http-method", "--worker-class=gevent", "--config=/gunicorn.conf.py", "--workers=1", "--worker-connections=1000", "--bind", "0.0.0.0:80", "server:app"]

--- a/images/gunicorn/gunicorn.conf.py
+++ b/images/gunicorn/gunicorn.conf.py
@@ -1,0 +1,3 @@
+def on_starting(server):
+    import afl
+    afl.init()

--- a/images/gunicorn/server.py
+++ b/images/gunicorn/server.py
@@ -1,3 +1,4 @@
+import sys
 from base64 import b64encode
 
 
@@ -5,6 +6,12 @@ RESERVED_HEADERS = ("CONTENT_LENGTH", "CONTENT_TYPE")
 
 
 def app(environ, start_response) -> list[bytes]:
+    try:
+        body : bytes = environ["wsgi.input"].read()
+    except Exception as ex:
+        start_response("500 Input Error", [("Content-Type", "text/plain")], sys.exc_info())
+        return [("Exception during input read: %s" % (str(ex))).encode("ascii", "replace")]
+
     response_body: bytes = (
         b'{"headers":['
         + b",".join(
@@ -17,7 +24,7 @@ def app(environ, start_response) -> list[bytes]:
             if k.startswith("HTTP_") or k in RESERVED_HEADERS
         )
         + b'],"body":"'
-        + b64encode(environ["wsgi.input"].read())
+        + b64encode(body)
         + b'","version":"'
         + b64encode(environ["SERVER_PROTOCOL"].encode("latin1"))
         + b'","uri":"'

--- a/images/hypercorn/Dockerfile
+++ b/images/hypercorn/Dockerfile
@@ -5,6 +5,9 @@ RUN apt -y update && apt -y upgrade && apt -y install python3-pip && git clone '
 ARG APP_VERSION
 RUN cd /app/hypercorn && git checkout $APP_VERSION && pip install . --break-system-packages
 
+# observation: /tmp/hypercorn/trace empty if initialized later
+RUN sed -i "s/^from hypercorn.__main__ import main/import afl\nafl.init()\nfrom hypercorn.__main__ import main/" $(which hypercorn)
+
 COPY server.py .
 
-CMD ["hypercorn", "server:app", "-b", "0.0.0.0:80"]
+CMD ["afl-showmap", "-o", "/tmp/trace", "-t", "2147483647", "--", "hypercorn", "server:app", "-b", "0.0.0.0:80"]

--- a/images/werkzeug/Dockerfile
+++ b/images/werkzeug/Dockerfile
@@ -4,9 +4,11 @@ RUN apt -y update && apt -y upgrade && apt -y install pkg-config libssl-dev zlib
 
 RUN cd /app/cpython && git checkout $APP_VERSION && ./configure && make -j$(nproc) && make install
 
+RUN cd /app/python-afl && python3 -m pip install . --break-system-packages
+
 ARG APP_VERSION
 RUN cd /app/werkzeug && git checkout $APP_VERSION && python3 -m pip install . --break-system-packages
 
 COPY ./server.py /app
 
-CMD ["python3", "./server.py"]
+CMD ["afl-showmap", "-o", "/tmp/trace", "-t", "2147483647", "--", "python3", "./server.py"]

--- a/images/werkzeug/server.py
+++ b/images/werkzeug/server.py
@@ -25,4 +25,7 @@ if __name__ == "__main__":
     from werkzeug.serving import run_simple, WSGIRequestHandler
     WSGIRequestHandler.protocol_version = "HTTP/1.1"
 
+    import afl
+    afl.init()
+
     run_simple("0.0.0.0", 80, application)


### PR DESCRIPTION
When you commented:

> `# For some reason, afl-showmap just isn't working...`

What kind of *not working* is that referring to?
* afl-showmap does print `-- Program output begins --`
* `/tmp/*/trace` files do fill up
* the `fuzz` command in the repls starts claiming it encountered "new coverage tuples"
* I *think* they work because I got more "interesting" results, though my sample is small.
Unfortunately I have no idea how they could be validated beyond that.

Should these just be enabled (patch attached)?
* gunicorn
* hypercorn
* werkzeug
* cherrypy
* <del>aiohttp_ext (duplicates `aiohttp` - without NO_EXTENSIONS)</del>
* <del>werkzeug_wsgi (duplicates `werkzeug` - matching other wsgi server.py structure)</del>

Or I am misunderstanding the criteria of when the traces become useful, and kindly request a pointer on how one would test whether the traces contain anything remotely useful.