### PR TITLE
Assess discrepancy type with GT/LT sub-results for visually and functionally pleasing grid symmetry

### DIFF
--- a/tools/diff_fuzz.py
+++ b/tools/diff_fuzz.py
@@ -208,7 +208,7 @@ def categorize_discrepancy(
                     print(r1)
                     print(r2)
                     return DiscrepancyType.SUBTLE_DISCREPANCY_GT
-                if r1 < r2:
+                if r2 > r1:
                     print(f"{s1.name} and {s2.name} accepted with different interpretations.")
                     print(r1)
                     print(r2)

--- a/tools/http1.py
+++ b/tools/http1.py
@@ -34,7 +34,7 @@ METHODS: Final[list[bytes]] = [
     b"MKWORKSPACE",
     b"MOVE",
     b"NOTIFY",
-    b"ORDERPATCH"
+    b"ORDERPATCH",
     b"PATCH",
     b"PAUSE",
     b"PLAY",
@@ -87,6 +87,17 @@ class HTTPRequest:
     def has_header(self: Self, name: bytes, value: bytes | None = None) -> bool:
         return any(k.lower() == name.lower() and (value is None or value == v) for k, v in self.headers)
 
+    def __gt__(self: Self, other: object) -> bool:
+        if not isinstance(other, HTTPRequest):
+            return True
+        return (
+            self.method > other.method
+            or self.uri > other.uri
+            or self.headers > other.headers
+            or self.body > other.body
+            or (self.version > other.version and not (other.version == b"" or self.version == b""))
+        )
+
     def __eq__(self: Self, other: object) -> bool:
         if not isinstance(other, HTTPRequest):
             return False
@@ -113,6 +124,11 @@ class HTTPResponse:
     headers: list[tuple[bytes, bytes]]
     # The body (e.g. b"{}")
     body: bytes
+
+    def __gt__(self: Self, other: object) -> bool:
+        if not isinstance(other, HTTPResponse):
+            return True
+        return self.code > other.code
 
     def __eq__(self: Self, other: object) -> bool:
         if not isinstance(other, HTTPResponse):

--- a/tools/repl.py
+++ b/tools/repl.py
@@ -121,7 +121,7 @@ def print_grid(grid: tuple[tuple[bool | None, ...], ...], labels: list[str]) -> 
     for label in labels:
         print(label.ljust(column_width), end="")
     print()
-    for label, row in zip(labels[:-1], grid[:-1]):
+    for label, row in zip(labels, grid):
         print(label.ljust(column_width), end="")
         for entry in row:
             print(


### PR DESCRIPTION
When doing the discrepancy assessment on the greater operator instead of equality (its easier to get the comparison method wrong and) the grid can truly ✨[🇸🇵🇦🇷🇰🇱🇪](https://fi.wikipedia.org/wiki/Panama)✨ with unique indicators for the various symmetric pairs. Which I believe is rather helpful in spotting which server is just visual clutter, and where to look closer, especially with larger grids.

re: my comment at #31