### PR TITLE
Add HTTP/2 Golang stdlib origin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,16 @@ services:
       context: ./images/go_stdlib
     x-props:
       role: origin
+  go_stdlib_h2:
+    build:
+      args:
+        APP_BRANCH: master
+        APP_REPO: https://go.googlesource.com/net
+        APP_SOURCE: app_h2.go
+        APP_VERSION: c1e936d465e7739236961c3281539e2383c96d74
+      context: ./images/go_stdlib_h2
+    x-props:
+      role: h2_origin
   go_stdlib_proxy:
     build:
       args:

--- a/images/go_stdlib_h2/Dockerfile
+++ b/images/go_stdlib_h2/Dockerfile
@@ -1,0 +1,24 @@
+FROM http-garden-soil:latest
+
+RUN apt -y update \
+ && apt -y upgrade \
+ && apt -y install --no-install-recommends golang
+
+ARG APP_REPO
+RUN git clone "$APP_REPO"
+
+ARG APP_BRANCH
+ARG APP_VERSION
+RUN cd net \
+    && git pull origin "$APP_BRANCH" \
+    && git checkout "$APP_VERSION"
+
+ARG APP_SOURCE
+COPY $APP_SOURCE .
+RUN go mod init app \
+    && go mod edit -replace=golang.org/x/net=./net \
+    && go mod edit -require=golang.org/x/net@v0.0.0 \
+    && go mod tidy \
+    && go build -o app "$APP_SOURCE"
+
+CMD ["./app"]

--- a/images/go_stdlib_h2/app_h2.go
+++ b/images/go_stdlib_h2/app_h2.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+func handle_request(w http.ResponseWriter, req *http.Request) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	fmt.Fprintf(w, "{\"headers\":[")
+	i := 1
+	for canonical_key, headers := range req.Header {
+		j := 1
+		for _, value := range headers {
+			fmt.Fprintf(w, "[\"%s\",\"%s\"]", base64.StdEncoding.EncodeToString([]byte(canonical_key)), base64.StdEncoding.EncodeToString([]byte(value)))
+			if i != len(req.Header) || j != len(headers) {
+				fmt.Fprintf(w, "%s", ",")
+			}
+			j = j + 1
+		}
+		i = i + 1
+	}
+	if req.Host != "" {
+		if i > 1 {
+			fmt.Fprintf(w, ",")
+		}
+		i = i + 1
+		fmt.Fprintf(w, "[\"SG9zdA==\",\"%s\"]", base64.StdEncoding.EncodeToString([]byte(req.Host)))
+	}
+	if len(req.TransferEncoding) != 0 {
+		if i > 1 {
+			fmt.Fprintf(w, ",")
+		}
+		i = i + 1
+		fmt.Fprintf(w, "[\"VHJhbnNmZXItRW5jb2Rpbmc=\",\"%s\"]", base64.StdEncoding.EncodeToString([]byte(strings.Join(req.TransferEncoding[:], ","))))
+	}
+	fmt.Fprintf(w, "],")
+	fmt.Fprintf(w, "\"body\":\"%s\",", base64.StdEncoding.EncodeToString(body))
+	fmt.Fprintf(w, "\"method\":\"%s\",", base64.StdEncoding.EncodeToString([]byte(req.Method)))
+	fmt.Fprintf(w, "\"version\":\"%s\",", base64.StdEncoding.EncodeToString([]byte(req.Proto)))
+	fmt.Fprintf(w, "\"uri\":\"%s\"}", base64.StdEncoding.EncodeToString([]byte(req.URL.String())))
+}
+
+func main() {
+	s := &http.Server{
+		Addr:           "0.0.0.0:80",
+		Handler:        h2c.NewHandler(http.HandlerFunc(handle_request), &http2.Server{}),
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	s.ListenAndServe()
+}


### PR DESCRIPTION
Adds a Golang stdlib HTTP/2 origin.

Since h2c is not made available in net/http, this module clones from golang.org/x/net. The actual h2 implemention is identical, minus the TLS stuff. 