### PR TITLE
Add h2c to Jetty

### DIFF
--- a/images/eclipse_jetty/Dockerfile
+++ b/images/eclipse_jetty/Dockerfile
@@ -21,7 +21,7 @@ RUN javac -cp ./jetty-home/target/jetty-home/lib/jetty-jakarta-servlet-api-*.jar
 
 # Configure Jetty
 WORKDIR /app/jetty.project/base
-RUN java -jar ../jetty-home/target/jetty-home/start.jar --add-module=http,ee10-deploy
+RUN java -jar ../jetty-home/target/jetty-home/start.jar --add-module=http,http2c,ee10-deploy
 RUN mkdir -p webapps/root/WEB-INF/classes \
  && cp ../Server.class webapps/root/WEB-INF/classes
 COPY web.xml webapps/root/WEB-INF


### PR DESCRIPTION
Interestingly, Jetty supports h2c (with prior knowledge) and h1 on the same port, which I actually didn't know was possible, so there's no need to create a separate eclipse_jetty_h2. 