### PR TITLE
Add h2 to hypercorn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -295,6 +295,7 @@ services:
         APP_VERSION: 6cb9c5cc11c5372d59ffb8348345e308bc2f1067
       context: ./images/hypercorn
     x-props:
+      requires-tls: true
       role: origin
   ktor:
     build:

--- a/images/hypercorn/Dockerfile
+++ b/images/hypercorn/Dockerfile
@@ -12,4 +12,4 @@ RUN cd /app/hypercorn \
 
 COPY server.py .
 
-CMD hypercorn server:app -b 0.0.0.0:80
+CMD hypercorn server:app --certfile /app/garden.crt --keyfile /app/garden.crt.key --bind 0.0.0.0:443


### PR DESCRIPTION
Hypercorn only supports h2c via upgrade, not prior knowledge, which is not great for testing the h2 implementation. We can fix it by just using 'real' h2 with TLS. 