### PR TITLE
Add h2c to grizzly

### DIFF
--- a/images/eclipse_grizzly/GardenServer.java
+++ b/images/eclipse_grizzly/GardenServer.java
@@ -4,10 +4,12 @@ import java.io.Writer;
 import java.io.ByteArrayOutputStream;
 import java.util.Base64;
 
+import org.glassfish.grizzly.http2.Http2AddOn;
 import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.Request;
 import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.grizzly.http.server.NetworkListener;
 
 public class GardenServer {
     private static String base64_encode(byte[] input) {
@@ -15,7 +17,10 @@ public class GardenServer {
     }
 
     public static void main(String[] args) throws IOException {
-        final HttpServer server = HttpServer.createSimpleServer();
+        final HttpServer server = new HttpServer();
+        NetworkListener listener = new NetworkListener("grizzly", "0.0.0.0", 80);
+        listener.registerAddOn(new Http2AddOn());
+        server.addListener(listener);
         for (HttpHandler handler: server.getServerConfiguration().getHttpHandlers().keySet()) {
             server.getServerConfiguration().removeHttpHandler(handler);
         }


### PR DESCRIPTION
Like Jetty, Grizzly supports h2c with prior knowledge and h1 on the same port.